### PR TITLE
Add Opt to Override Default Header Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Total: 300
 Per-Page: 10
 ```
 
+### Using Custom Header Names
+
+Override any number of pagination header names by passing opts with a `header_names` keyword list like so:
+
+```elixir
+Screenever.Headers.paginate(page,
+  header_names: [
+    total: "total",
+    link: "link",
+    per_page: "per-page",
+    total_pages: "total-pages",
+    page_number: "page-number"
+  ]
+)
+```
+
 ## Contributing
 
 Contributions of all types are welcomed and encouraged.  Please

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Per-Page: 10
 
 ### Using Custom Header Names
 
-Override any number of pagination header names by passing opts with a `header_names` keyword list like so:
+Override any number of pagination header names by passing opts with a `header_keys` keyword list like so:
 
 ```elixir
 Screenever.Headers.paginate(page,
-  header_names: [
+  header_keys: [
     total: "total",
     link: "link",
     per_page: "per-page",

--- a/lib/scrivener/headers.ex
+++ b/lib/scrivener/headers.ex
@@ -122,8 +122,8 @@ defmodule Scrivener.Headers do
     links
   end
 
-  defp generate_header_keys(header_names: header_names) do
-    custom_header_keys = Map.new(header_names)
+  defp generate_header_keys(header_keys: header_keys) do
+    custom_header_keys = Map.new(header_keys)
 
     Map.merge(@default_header_keys, custom_header_keys)
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
-%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm"},
-  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
-  "scrivener": {:hex, :scrivener, "2.3.0", "16b1d744202d47233798205447b35592d96a209241c566304f84ddef63c718b2", [:mix], [], "hexpm"}}
+%{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
+  "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm", "14dde2b851709115a578e43158c13ad97724eceb70320c51784952b88ee64814"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm", "3b1dcad3067985dd8618c38399a8ee9c4e652d52a17a4aae7a6d6fc4fcc24856"},
+  "ex_doc": {:hex, :ex_doc, "0.16.4", "4bf6b82d4f0a643b500366ed7134896e8cccdbab4d1a7a35524951b25b1ec9f0", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "90e39c592b4952d35eb122b70d656a8b2ffa248d7b0fa428b314ce2176c69861"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], [], "hexpm", "33dd09e615daab5668c15cc3a33829892728fdbed910ab0c0a0edb06b45fc54d"},
+  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm", "c1c408c57a1e4c88c365b9aff1198c350e22b765dbb97a460e9e6bd9364c6194"},
+  "scrivener": {:hex, :scrivener, "2.3.0", "16b1d744202d47233798205447b35592d96a209241c566304f84ddef63c718b2", [:mix], [], "hexpm", "55f4e512175dd46c428acecf3306e7d2606cef886c1e4c6293d30b4499db7717"},
+}

--- a/test/scrivener/headers_test.exs
+++ b/test/scrivener/headers_test.exs
@@ -56,6 +56,41 @@ defmodule Scrivener.HeadersTests do
     assert headers["link"] =~ ~s(<http://www.example.com:1337/test?foo=bar&page=1>)
   end
 
+  test "updates the keys used with the pagination headers" do
+    page = %Page{page_number: 5, page_size: 10, total_pages: 5, total_entries: 50}
+
+    header_keys =
+      paginated_headers(page, 80,
+        header_names: [
+          total: "total_items",
+          link: "link_url",
+          per_page: "per_page",
+          total_pages: "total_pages",
+          page_number: "page_number"
+        ]
+      )
+
+    assert Enum.all?(
+             ["link_url", "page_number", "per_page", "total_items", "total_pages"],
+             &Map.has_key?(header_keys, &1)
+           )
+  end
+
+  test "updates a single key used with the pagination headers" do
+    page = %Page{page_number: 5, page_size: 10, total_pages: 5, total_entries: 50}
+
+    header_keys =
+      paginated_headers(page, 80,
+        header_names: [
+          total: "total_items"
+        ]
+      )
+
+    refute is_nil(header_keys["total_items"])
+    assert is_nil(header_keys["total"])
+    refute is_nil(header_keys["link"])
+  end
+
   test "shows links build from x-forwarded headers" do
     page = %Page{page_number: 5, page_size: 10, total_pages: 5, total_entries: 50}
 

--- a/test/scrivener/headers_test.exs
+++ b/test/scrivener/headers_test.exs
@@ -61,7 +61,7 @@ defmodule Scrivener.HeadersTests do
 
     header_keys =
       paginated_headers(page, 80,
-        header_names: [
+        header_keys: [
           total: "total_items",
           link: "link_url",
           per_page: "per_page",
@@ -81,7 +81,7 @@ defmodule Scrivener.HeadersTests do
 
     header_keys =
       paginated_headers(page, 80,
-        header_names: [
+        header_keys: [
           total: "total_items"
         ]
       )


### PR DESCRIPTION
# Overview

Closes #7 .

Updated the paginate function to let users pass a keyword list of pagination header names to override the default ones.

Thanks to the author of #8 for the inspiration.